### PR TITLE
Pin and modernize base image, matching jonasbn/ebirah

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,29 @@
+# check=skip=InvalidDefaultArgInFrom
+
 # REF: https://docs.docker.com/engine/reference/builder/
 # REF: https://hub.docker.com/_/perl
-FROM perl:5.42.2-bullseye
+# REF: https://github.com/Perl/docker-perl
+
+# Pinned by digest so the build is reproducible; bump the tag/digest pair
+# together when moving to a new perl/Debian release.
+ARG BASE_IMAGE=perl:5.44.0-slim-trixie@sha256:c9aac2fcb8612b25b818df998413423eecf15d8d5175c98d1c10a069ac7e7f8f
+FROM ${BASE_IMAGE}
 
 # We point to the original repository for the image
-LABEL org.opencontainers.image.source https://github.com/jonasbn/perl-app-yak
+LABEL org.opencontainers.image.source="https://github.com/jonasbn/perl-app-yak"
+LABEL org.opencontainers.image.base.name="registry.hub.docker.com/library/perl:5.44.0-slim-trixie"
 
+# build-essential: required to compile Net::SSLeay (pulled in by LWP::Protocol::https);
+# the slim base image ships without a C compiler
 # libssl-dev: required to compile Net::SSLeay (pulled in by LWP::Protocol::https)
 # ca-certificates: needed for TLS certificate verification at runtime
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
+        build-essential \
         libssl-dev \
         ca-certificates \
+    && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
 # This is our yak work directory, we do not want to mix this


### PR DESCRIPTION
# Description

Reviewed [jonasbn/ebirah's Dockerfile](https://github.com/jonasbn/ebirah/blob/master/Dockerfile) for its base-image handling and adopted the same practice here:

- Base image is now referenced via `ARG BASE_IMAGE=...`, so it can be bumped or overridden in one place (or via `--build-arg`) instead of editing the `FROM` line.
- The image is pinned by digest, not just by tag: `perl:5.44.0-slim-trixie@sha256:c9aac2fcb8612b25b818df998413423eecf15d8d5175c98d1c10a069ac7e7f8f` (same digest ebirah uses, verified independently via `docker buildx imagetools inspect perl:5.44.0-slim-trixie`). Tags are mutable; the digest guarantees the exact same image bytes on every build.
- Added `# check=skip=InvalidDefaultArgInFrom` (same directive ebirah uses) to suppress BuildKit's lint warning about using an `ARG` default in `FROM` — the pattern is intentional here.
- Added an `org.opencontainers.image.base.name` label documenting the base image, matching OCI annotation conventions ebirah also follows.
- Moved from `perl:5.42.2-bullseye` (full, Debian 11) to `perl:5.44.0-slim-trixie` (slim, Debian 13), matching ebirah's base exactly rather than just adopting the pinning pattern in isolation.
- Since the slim image has no C compiler, added `build-essential` to the `apt-get install` list — `cpanm` needs it to build `Net::SSLeay` for `LWP::Protocol::https`. `apt-get clean -y` was added alongside the existing `rm -rf /var/lib/apt/lists/*` for good measure.

## Verification

Built and ran the image locally:

```sh
docker build -t yak-test .
docker run --rm --entrypoint yak yak-test --about --noconfig --checksums /usr/src/app/examples/checksums.json
```

Dependency install (`cpanm --notest --installdeps .`) completes successfully on the slim base, and `yak --about` runs correctly, confirming the build and entrypoint both still work end-to-end. Also confirmed there's no regression versus the current `master` Dockerfile's own quirks (e.g. `--about` still requires a checksums source either way — that's pre-existing behavior, unrelated to this change).

## Type of change

- [x] Infrastructure change, changes to actions, CI, tool and configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (confirmed via `docker build`, no BuildKit lint warnings)
- [ ] I have added tests that prove my fix is effective or that my feature works (Dockerfile isn't covered by the Perl test suite; verified manually via `docker build`/`docker run` as described above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
